### PR TITLE
Add trove classifiers and project links to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,18 +8,38 @@ DEPENDENCIES = [
     "websockets",
 ]
 
+def get_readme(readme_location="README.md"):
+    with open(readme_location, "r", "utf-8") as f:
+        readme = f.read()
+    return readme
+
 setup(
     name='async_bitfinex',
     version=VERSION,
     description='Python client for Bitfinex ',
+    long_description=get_readme(),
+    long_description_content_type="text/markdown",
     author='Ole Henrik Skogstrøm',
     author_email='henrik@amplify.no',
     url='https://github.com/ohenrik/async_bitfinex',
+    project_urls = {
+        "Documentation": "https://async_bitfinex.readthedocs.io/en/latest/",
+        "Source": "https://github.com/ohenrik/async_bitfinex"
+    }
     license='MIT',
     packages=find_packages(),
     install_requires=DEPENDENCIES,
     # download_url='https://github.com/ohenrik/bitfinex/tarball/%s' % version,
-    keywords=['bitfinex', 'bitcoin', 'btc', 'asyncio', 'websockets'],
-    classifiers=[],
+    keywords=['bitfinex', 'bitcoin', 'btc', 'asyncio', 'websockets']
+    classifiers=[
+        "License :: OSI Approved :: MIT License",
+        "Natural Language :: English",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
+        "Intended Audience :: Financial and Insurance Industry",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.7"
+    ],
     zip_safe=True
 )


### PR DESCRIPTION
Adding [trove classifiers](https://pypi.org/classifiers) is an excellent way to help with project discoverability.

Adding project URLs to the `setup.py` helps people get where they need to go, without guesswork.

I've also added the README as the long description for the package.